### PR TITLE
Fix loading of js/png files when having pvws on separate server from dbwr

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,6 +43,8 @@ you need to configure this via the environment variable
 
  * `PVWS_URL`: URL of PV Web Socket when not co-located with `dbwr.jar`,
    for example `ws://some.other.host.org:8081/pvws`
+ * `PVWS_HTTP_URL`: HTTP base URL of PV Web Socket when not co-located with `dbwr.jar`,
+   for example `http://some.other.host.org:8081/pvws`
 
 
 Client URLs

--- a/src/main/java/dbwr/WebDisplayRepresentation.java
+++ b/src/main/java/dbwr/WebDisplayRepresentation.java
@@ -35,6 +35,9 @@ public class WebDisplayRepresentation implements ServletContextListener
 	/** Custom ws://some_host.org:8081/pvws URL or <code>null</code> */
     public static final String pvws_url;
 	
+	/** Custom http://some_host.org:8081/pvws URL or <code>null</code> */
+    public static final String pvws_http_url;
+
 	static
 	{
 	    // Load display links for the start page from environment variables "DBWR1", "DBWR2", ...
@@ -75,6 +78,12 @@ public class WebDisplayRepresentation implements ServletContextListener
             pvws_url = null;
         else
             pvws_url = wsurl.trim();
+
+        final String http_url = System.getenv("PVWS_HTTP_URL");
+        if (http_url == null || http_url.trim().isEmpty())
+            pvws_http_url = null;
+        else
+            pvws_http_url = http_url.trim();
 	}
 
 	@Override

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -8,8 +8,17 @@
 <title>Display Builder Web Runtime</title>
 <link rel="shortcut icon" href="favicon.png">
 <link rel="stylesheet" type="text/css" href="css/widgets.css">
-<script type="text/javascript" src="../pvws/js/jquery.js"></script>
-<script type="text/javascript" src="../pvws/js/tablesort.js"></script>
+<%
+if (WebDisplayRepresentation.pvws_http_url != null)
+{
+  out.append("<script type=\"text/javascript\" src=\"" + WebDisplayRepresentation.pvws_http_url + "/js/tablesort.js\"></script>\n");
+  out.append("<script type=\"text/javascript\" src=\"" + WebDisplayRepresentation.pvws_http_url + "/js/jquery.js\"></script>\n");
+}
+else {
+  out.append("<script type=\"text/javascript\" src=\"../pvws/js/jquery.js\"></script>\n");
+  out.append("<script type=\"text/javascript\" src=\"../pvws/js/tablesort.js\"></script>\n");
+}
+%>
 </head>
 
 <body>

--- a/src/main/webapp/js/dbwr.js
+++ b/src/main/webapp/js/dbwr.js
@@ -116,7 +116,7 @@ class DisplayBuilderWebRuntime
     /** Construct data browser web runtime for a PV Web Socket
      *  @param pvws_url PV Web Socket URL
      */
-    constructor(pvws_url)
+    constructor(pvws_url, pvws_http_url)
     {
         this.display = "";
         this.info = jQuery("#info");
@@ -125,6 +125,7 @@ class DisplayBuilderWebRuntime
                              message   => this._handle_message(message));
         // Map of PV name to PVInfo
         this.pv_infos = {}
+        this.pvws_http_url = pvws_http_url;
     }
     
     /** @param message Message to log in 'info' span and console */
@@ -192,7 +193,14 @@ class DisplayBuilderWebRuntime
      */
     _handle_connection(connected)
     {
-        jQuery("#status").attr("src", connected ? "../pvws/img/connected.png" : "../pvws/img/disconnected.png");
+        if (this.pvws_http_url !== null && this.pvws_http_url !== "null") 
+        {
+          jQuery("#status").attr("src", connected ? this.pvws_http_url + "/img/connected.png" : this.pvws_http_url + "/img/disconnected.png");
+        }
+        else 
+        {
+          jQuery("#status").attr("src", connected ? "../pvws/img/connected.png" : "../pvws/img/disconnected.png");
+        }
         if (connected)
         {
             this.log("Initialize Widgets");

--- a/src/main/webapp/view.jsp
+++ b/src/main/webapp/view.jsp
@@ -28,9 +28,21 @@ out.append("<!--  Generated " + now + " -->\n");
 for (String c : WidgetFactory.css)
 	out.append("<link rel=\"stylesheet\" type=\"text/css\" href=\"widgets/" + c + "?V=" + UNIQUE + "\">\n");
 %>
-<script type="text/javascript" src="../pvws/js/jquery.js"></script>
-<script type="text/javascript" src="../pvws/js/base64.js"></script>
-<script type="text/javascript" src="../pvws/js/pvws.js?V=<%=UNIQUE%>"></script> 
+
+<%
+if (WebDisplayRepresentation.pvws_http_url != null)
+{
+  out.append("<script type=\"text/javascript\" src=\"" + WebDisplayRepresentation.pvws_http_url + "/js/jquery.js\"></script>\n");
+  out.append("<script type=\"text/javascript\" src=\"" + WebDisplayRepresentation.pvws_http_url + "/js/base64.js\"></script>\n");
+  out.append("<script type=\"text/javascript\" src=\"" + WebDisplayRepresentation.pvws_http_url + "/js/pvws.js?V=" + UNIQUE + "\"></script>\n");
+}
+else
+{
+  out.append("<script type=\"text/javascript\" src=\"../pvws/js/jquery.js\"></script>\n");
+  out.append("<script type=\"text/javascript\" src=\"../pvws/js/base64.js\"></script>\n");
+  out.append("<script type=\"text/javascript\" src=\"../pvws/js/pvws.js?V=" + UNIQUE + "\"></script>\n");
+}
+%>
 <script type="text/javascript" src="js/lib/jquery.event.drag.js"></script>
 <script type="text/javascript" src="js/lib/jquery.mousewheel.js"></script>
 <script type="text/javascript" src="js/flot/jquery.canvaswrapper.js"></script>
@@ -69,7 +81,16 @@ for (String js : WidgetFactory.js)
 
 <div id="info_panel">
 <span id="info">INFO</span>
-<img id="status" alt="Status" title="Connect/disconnect" src="../pvws/img/disconnected.png">
+<%
+if (WebDisplayRepresentation.pvws_http_url != null)
+{
+  out.append("<img id=\"status\" alt=\"Status\" title=\"Connect/disconnect\" src=\"" + WebDisplayRepresentation.pvws_http_url + "/img/disconnected.png\">\n");
+}
+else
+{
+  out.append("<img id=\"status\" alt=\"Status\" title=\"Connect/disconnect\" src=\"../pvws/img/disconnected.png\">\n");
+}
+%>
 </div>
 
 
@@ -139,7 +160,11 @@ else
 <%
 }
 %>
-let dbwr = new DisplayBuilderWebRuntime(wsurl);
+<%
+out.println("// Web Socket HTTP Base URL");
+out.println("let wsHttp = \"" + WebDisplayRepresentation.pvws_http_url + "\";");
+%>
+let dbwr = new DisplayBuilderWebRuntime(wsurl, wsHttp);
 
 jQuery("#status").click(() => dbwr.pvws.close() );
 


### PR DESCRIPTION
This is for the use case of running pvws on a separate server than dbwr (https://github.com/ornl-epics/dbwr#running-under-tomcat)

The current environment variable ```PVWS_URL``` works for changing the ws:// URL. But it doesn't work completely since dbwr loads several JS and PNG files from pvws and it is currently hard coded to assume pvws is on the same tomcat instance. For example
- https://github.com/ornl-epics/dbwr/blob/main/src/main/webapp/view.jsp#L31
- https://github.com/ornl-epics/dbwr/blob/main/src/main/webapp/index.jsp#L11

This PR adds a second environment variable ```PVWS_HTTP_URL``` which should be set to something like http://my-pvws-server/pvws


Another approach that could be cleaner would be to have these 3 environment variables like so.
```
PVWS_HTTP_PROTOCOL=http
PVWS_WS_PROTOCOL=ws
PVWS_HOST=my-pvws-server
```

Or maybe you have a better idea. I can change the PR no problem, this was just my first go at it