### PR TITLE
databrowser: fix incorrect time axis when showing more then on plot

### DIFF
--- a/src/main/webapp/widgets/databrowser.js
+++ b/src/main/webapp/widgets/databrowser.js
@@ -156,7 +156,6 @@ DisplayBuilderWebRuntime.prototype.widget_update_methods["databrowser"] = functi
     let trace, traces = widget.data("traces");
     for (trace of traces)
         trace.update(data.pv, time, data.value);
-    __replot(widget, traces);
 }
 
 function __scroll(widget, traces)


### PR DESCRIPTION
It looks like removing  __replot() function that was called asynchronously with __replot() call in __scroll() function fixed the problem. I can't see any unwanted side effects of removing __replot().