### PR TITLE
Support string formatting following PVWS change

### DIFF
--- a/src/main/webapp/widgets/textupdate.js
+++ b/src/main/webapp/widgets/textupdate.js
@@ -84,6 +84,10 @@ function format_pv_data_as_text(widget, data)
                 text = (data.value | 0).toString(2);
                 text = "0b" + text;
             }
+            else if (widget.data("format") == "string" && Array.isArray(data.value))
+            {
+                text = String.fromCharCode.apply(String, data.value);
+            }
             else
             {
                 if (data.precision === undefined)


### PR DESCRIPTION
This change is required once https://github.com/ornl-epics/pvws/pull/23 has been merged. The change to PVWS means that the original byte arrays will be sent and will not automatically be converted to strings. If the format option is set to 'string' then it is up to the client to perform the conversion. See discussion: https://github.com/ornl-epics/pvws/issues/20. I have added this conversion code to the DBWR client. 